### PR TITLE
Trn1 sphinx doc fix

### DIFF
--- a/doc/frameworks/pytorch/using_pytorch.rst
+++ b/doc/frameworks/pytorch/using_pytorch.rst
@@ -262,7 +262,8 @@ during the PyTorch DDP initialization.
 
 .. note::
 
-  The SageMaker PyTorch estimator doesn’t use ``torchrun`` for distributed training.
+  The SageMaker PyTorch estimator operates ``mpirun`` in the backend.
+  It doesn’t use ``torchrun`` for distributed training.
 
 For more information about setting up PyTorch DDP in your training script,
 see `Getting Started with Distributed Data Parallel
@@ -292,11 +293,13 @@ using two ``ml.p4d.24xlarge`` instances:
 
     pt_estimator.fit("s3://bucket/path/to/training/data")
 
+.. _distributed-pytorch-training-on-trainium:
+
 Distributed PyTorch Training on Trainium
 ========================================
 
-SageMaker Training on Trainium instances now supports the `xla`
-package through `torchrun`. With this, you do not need to manually pass RANK, 
+SageMaker Training on Trainium instances now supports the ``xla``
+package through ``torchrun``. With this, you do not need to manually pass RANK,
 WORLD_SIZE, MASTER_ADDR, and MASTER_PORT. You can launch the training job using the
 :class:`sagemaker.pytorch.estimator.PyTorch` estimator class
 with the ``torch_distributed`` option as the distribution strategy.
@@ -309,8 +312,8 @@ with the ``torch_distributed`` option as the distribution strategy.
 
   SageMaker Debugger and Profiler are currently not supported with Trainium instances.
 
-Adapt Your Training Script
---------------------------
+Adapt Your Training Script to Initialize with the XLA backend
+-------------------------------------------------------------
 
 To initialize distributed training in your script, call
 `torch.distributed.init_process_group
@@ -333,8 +336,8 @@ For detailed documentation about modifying your training script for Trainium, se
 
 For up-to-date information on supported backends for Trainium instances, see `AWS Neuron Documentation <https://awsdocs-neuron.readthedocs-hosted.com/en/latest/index.html>`_.
 
-Launching a Distributed Training Job
-------------------------------------
+Launching a Distributed Training Job on Trainium
+------------------------------------------------
 
 You can run multi-node distributed PyTorch training jobs on Trainium instances using the
 :class:`sagemaker.pytorch.estimator.PyTorch` estimator class.
@@ -346,10 +349,10 @@ With the ``torch_distributed`` option, the SageMaker PyTorch estimator runs a Sa
 training container for PyTorch Neuron, sets up the environment, and launches
 the training job using the ``torchrun`` command on each worker with the given information.
 
-.. note::
+**Examples**
 
-The following example shows how to run a PyTorch training using ``torch_distributed`` in SageMaker
-using one ``ml.trn1.2xlarge`` and two ``ml.trn1.32xlarge`` instances:
+The following examples show how to run a PyTorch training using ``torch_distributed`` in SageMaker
+on one ``ml.trn1.2xlarge`` instance and two ``ml.trn1.32xlarge`` instances:
 
 .. code:: python
 

--- a/src/sagemaker/pytorch/estimator.py
+++ b/src/sagemaker/pytorch/estimator.py
@@ -169,14 +169,16 @@ class PyTorch(Framework):
                     To learn more, see `Distributed PyTorch Training
                     <https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#distributed-pytorch-training>`_.
 
-                **To enable Torch Distributed (Trainium Instances):**
+                **To enable Torch Distributed (for Trainium instances only):**
 
                     .. code:: python
-                    {
-                        "torch_distributed": {
-                            "enabled": True
+
+                        {
+                            "torch_distributed": {
+                                "enabled": True
+                            }
                         }
-                    }
+
                     To learn more, see `Distributed PyTorch Training on Trainium
                     <https://sagemaker.readthedocs.io/en/stable/frameworks/pytorch/using_pytorch.html#distributed-pytorch-training-on-trainium>`_.
 


### PR DESCRIPTION
*Description of changes:*

fix doc syntax to pass the sphinx build

*Testing done:*

tox -e sphinx

```
______________________________________________________________________ summary _______________________________________________________________________
  sphinx: commands succeeded
  congratulations :)
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the Python SDK team
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
